### PR TITLE
feat: primera versión del script de experimentación

### DIFF
--- a/experimentation_script.py
+++ b/experimentation_script.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+Script sencillo para automatizar la evaluación de templates contra múltiples modelos.
+Modifica directamente las listas `template_ids` y `models` en el código.
+Usa la librería `logging` para generar salidas estructuradas y maneja excepciones de red.
+"""
+import logging
+import requests
+import sys
+
+# --- Configuración: modifica aquí los templates y modelos para la experimentación ---
+base_url = 'http://localhost:8002'
+poet_url = 'http://localhost:8000'
+template_ids = ['design_pattern_code_eval_1group_yn', 'design_patterns_1group_yn']
+models = ['gemini']
+
+# Configuración básica del logger
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    datefmt='%Y-%m-%d %H:%M:%S'
+)
+logger = logging.getLogger(__name__)
+
+
+def fetch_template(template_id: str) -> dict:
+    """Obtiene un template por ID desde la API de POET."""
+    url = f"{poet_url}/api/v1/templates/{template_id}"
+    logger.info("Solicitando template '%s'...", template_id)
+    try:
+        resp = requests.get(url, timeout=10) # los get son rápidos
+        resp.raise_for_status()
+        data = resp.json()
+        logger.info("Template '%s' obtenido correctamente.", template_id)
+        return data
+    except requests.RequestException as e:
+        logger.error("Error al solicitar template '%s': %s", template_id, e)
+        raise
+    except ValueError as e:
+        logger.error("Respuesta JSON inválida para template '%s': %s", template_id, e)
+        raise
+
+
+def evaluate_template(template: dict, model: str) -> dict:
+    """Evalúa el template contra un modelo específico en el servicio de patterns.
+    Extrae y registra métricas clave del resultado."""
+    tid = template.get('id', 'unknown')
+    url = f"{base_url}/patterns/evaluateYN/{model}"
+    logger.info("Enviando evaluación para TemplateID=%s con modelo '%s'...", tid, model)
+    try:
+        resp = requests.post(url, json=template, timeout=60) # esto puede tardar mucho dependiendo de la template
+        resp.raise_for_status()
+        result = resp.json()
+    except requests.RequestException as e:
+        logger.error("Error en la petición de evaluación (TemplateID=%s, modelo=%s): %s", tid, model, e)
+        raise
+    except ValueError as e:
+        logger.error("Respuesta JSON inválida al evaluar TemplateID=%s con modelo=%s: %s", tid, model, e)
+        raise
+
+    # Métricas del resultado
+    passed = result.get('passed cases / total tests', 'N/A')
+    failed = result.get('failed cases / total tests', 'N/A')
+    rate = result.get('evaluation success rate', 'N/A')
+    try:
+        rate_display = f"{float(rate):.2f}%"
+    except (ValueError, TypeError):
+        rate_display = 'N/A'
+
+    logger.info(
+        "Resultado TemplateID=%s, Modelo='%s' → Passed / Total: %s, Failed / Total: %s, Success Rate: %s",
+        tid, model, passed, failed, rate_display
+    )
+    return result
+
+
+if __name__ == '__main__':
+    total = len(template_ids) * len(models)
+    logger.info("Iniciando proceso: %d template(s) x %d modelo(s) = %d solicitudes", len(template_ids), len(models), total)
+
+    for template_id in template_ids:
+        try:
+            template = fetch_template(template_id)
+        except Exception:
+            continue
+
+        for model in models:
+            try:
+                _ = evaluate_template(template, model)
+            except Exception:
+                continue
+
+    logger.info("Proceso de pruebas finalizado.")

--- a/src/modules/patterns/controllers.py
+++ b/src/modules/patterns/controllers.py
@@ -2,11 +2,11 @@ from fastapi import HTTPException
 from src.modules.patterns.services import PatternService
 
 class PatternController:
-    async def evaluate_pattern(code, pattern, patternList=None):
+    async def evaluate_pattern(code, pattern, patternList=None, model="gemini"):
         try:
             print("LLAMANDO AL SERVICIO")
             # Llamar al servicio de negocio
-            result = await PatternService().evaluate(code, pattern, patternList)
+            result = await PatternService().evaluate(code, pattern, model, patternList)
 
             # Devolver respuesta
             return result
@@ -14,11 +14,11 @@ class PatternController:
         except Exception as e:
             raise HTTPException(status_code=500, detail=str(e))
 
-    async def evaluate_YN(template):
+    async def evaluate_YN(template, model):
         try:
             print("LLAMANDO AL SERVICIO")
             # Llamar al servicio de negocio
-            result = await PatternService().evaluate_YN(template)
+            result = await PatternService().evaluate_YN(template, model)
 
             # Devolver respuesta
             return result

--- a/src/modules/patterns/routes.py
+++ b/src/modules/patterns/routes.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter
+from fastapi import APIRouter, Path
 from src.modules.patterns.models import PatternRequest
 from src.modules.patterns.controllers import PatternController
 
@@ -11,7 +11,7 @@ async def evaluate(request: PatternRequest):
     print("LLAMANDO AL CONTROLADOR")
     return await PatternController.evaluate_pattern(request.code, request.pattern, request.patternList)
 
-@patterns_router.post("/evaluateYN")
-async def evaluateYN(template: dict):
+@patterns_router.post("/evaluateYN/{model}")
+async def evaluateYN(template: dict, model: str = Path(..., description="Nombre del modelo, e.g. 'gemini', 'openai'")):
     print("LLAMANDO AL CONTROLADOR")
-    return await PatternController.evaluate_YN(template)
+    return await PatternController.evaluate_YN(template, model)

--- a/src/modules/patterns/services.py
+++ b/src/modules/patterns/services.py
@@ -4,13 +4,13 @@ from api_client.poet_api import PoetAPI
 
 class PatternService:
 
-    async def evaluate(self, code: str, pattern: str, patternList=None):
+    async def evaluate(self, code: str, pattern: str, model, patternList=None):
         # No hace falta generar inputs con POET en este caso
         payload = self._generate_payload(code, pattern, patternList)
         print("PAYLOAD:", payload)
 
         # Evaluar resultados
-        return await Utils()._calculate_success_ratio(payload, "mc" if patternList else "wh_question")
+        return await Utils()._calculate_success_ratio(payload, "mc" if patternList else "wh_question", model)
         
 
     def _generate_payload(self, code, pattern, patternList=None): # Añadimos una lista que es opcional en el caso de utilizar el evaluador mc
@@ -24,7 +24,7 @@ class PatternService:
             payload[0]["query"] = payload[0]["query"] + options
         return payload
     
-    async def evaluate_YN(self, template):
+    async def evaluate_YN(self, template, model):
         response = PoetAPI().generate_inputs_with_template(template)
         raw = response.text
         try:
@@ -35,4 +35,4 @@ class PatternService:
         print("PAYLOAD:", dict_payload)
 
         # Evaluar resultados
-        return await Utils()._calculate_success_ratio(dict_payload, "yes_no")
+        return await Utils()._calculate_success_ratio(dict_payload, "yes_no", model)

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,7 +20,7 @@ class Utils:
                 response = await client.textChat(query)
             case "ollama":
                 response = await OllamaAPI().textChat(query)
-                response = response["response"]
+                response = response.get("response", "No response key found in API output")
             case "openai":
                 response = await OpenAPI().textChat(query, os.getenv("OPENAI_API_KEY"))
             case other:


### PR DESCRIPTION
Se ha creado un script para automatizar la experimentación, hay que indicar los template_id a evaluar y los modelos a usar, de esta manera, interactua con POET para obtener las templates, y ejecuta los servicios de obtencion de queries, llamadas a los LLM y evaluacion con EVA de manera automática. Closes #2 